### PR TITLE
feat(cal): add hover for day

### DIFF
--- a/projects/cal/package.json
+++ b/projects/cal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k5cjs/cal",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "peerDependencies": {
     "@angular/common": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "@angular/core": "^14.0.0 || ^15.0.0 || ^16.0.0"

--- a/projects/cal/src/lib/components/kc-cal-day/kc-cal-day.component.scss
+++ b/projects/cal/src/lib/components/kc-cal-day/kc-cal-day.component.scss
@@ -53,4 +53,21 @@
       rounded
       border-rose-600;
   }
+
+  &--hovered {
+    @apply
+      bg-indigo-100;
+  }
+
+  &--hovered-other {
+    @apply
+      bg-indigo-50;
+  }
+
+  &--selected-other {
+    @apply
+      bg-amber-300;
+
+    color: #fff;
+  }
 }

--- a/projects/cal/src/lib/components/kc-cal-day/kc-cal-day.component.spec.ts
+++ b/projects/cal/src/lib/components/kc-cal-day/kc-cal-day.component.spec.ts
@@ -172,7 +172,7 @@ describe('CalDay', () => {
   });
 
   it('check if is only one', () => {
-    const date = new Date();
+    const date = removeTime(new Date());
 
     component.day = date;
     component.month = date;
@@ -287,5 +287,193 @@ describe('CalDay', () => {
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(markForCheckSpy).not.toHaveBeenCalled();
+  });
+
+  it('should have offset day selected', () => {
+    const date = new Date();
+    const prevMonthDay = new Date(date.getFullYear(), date.getMonth() - 1, 1);
+
+    component.day = prevMonthDay;
+    component.month = date;
+
+    spyOnProperty(selector, 'from').and.returnValue(prevMonthDay);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.classList).toContain('kc-cal-day--selected-other');
+    expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(252, 211, 77)');
+  });
+
+  describe('when hovering over day', () => {
+    it('should show hover on single day', () => {
+      const date = new Date();
+      component.day = date;
+      component.month = date;
+
+      const compiled = fixture.nativeElement as HTMLElement;
+
+      compiled.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      fixture.detectChanges();
+
+      expect(compiled.classList).toContain('kc-cal-day--hovered');
+      expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(224, 231, 255)');
+    });
+
+    it('should show hover over offset day', () => {
+      const date = new Date();
+
+      component.day = new Date(date.getFullYear(), date.getMonth() - 1, 1);
+      component.month = date;
+
+      const compiled = fixture.nativeElement as HTMLElement;
+
+      compiled.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      fixture.detectChanges();
+
+      expect(compiled.classList).toContain('kc-cal-day--hovered-other');
+      expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(238, 242, 255)');
+    });
+
+    it('should not show hover on selected', () => {
+      const date = new Date();
+      component.day = date;
+      component.month = date;
+
+      spyOnProperty(selector, 'from').and.returnValue(date);
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+
+      compiled.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      fixture.detectChanges();
+
+      expect(compiled.classList).toContain('kc-cal-day--selected');
+      expect(compiled.classList).not.toContain('kc-cal-day--hovered');
+      expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(255, 158, 27)');
+    });
+
+    it('should show hover between from & hovered', () => {
+      const date = new Date();
+
+      const from = new Date(date.getFullYear(), date.getMonth(), 1);
+      const middle = new Date(date.getFullYear(), date.getMonth(), 3);
+      const hoveredDate = new Date(date.getFullYear(), date.getMonth(), 5);
+
+      component.day = middle;
+      component.month = date;
+
+      spyOnProperty(selector, 'from').and.returnValue(from);
+      spyOnProperty(selector, 'hovered').and.returnValue(hoveredDate);
+
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+
+      expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(224, 231, 255)');
+    });
+
+    it('should show hover between hovered & from', () => {
+      const date = new Date();
+
+      const hoveredDate = new Date(date.getFullYear(), date.getMonth(), 1);
+      const middle = new Date(date.getFullYear(), date.getMonth(), 3);
+      const from = new Date(date.getFullYear(), date.getMonth(), 5);
+
+      component.day = middle;
+      component.month = date;
+
+      spyOnProperty(selector, 'hovered').and.returnValue(hoveredDate);
+      spyOnProperty(selector, 'from').and.returnValue(from);
+
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+
+      expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(224, 231, 255)');
+    });
+
+    it('should show hover between hovered & to', () => {
+      const date = new Date();
+
+      const hoveredDate = new Date(date.getFullYear(), date.getMonth(), 1);
+      const middle = new Date(date.getFullYear(), date.getMonth(), 3);
+      const to = new Date(date.getFullYear(), date.getMonth(), 5);
+
+      component.day = middle;
+      component.month = date;
+
+      spyOnProperty(selector, 'hovered').and.returnValue(hoveredDate);
+      spyOnProperty(selector, 'to').and.returnValue(to);
+
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+
+      expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(224, 231, 255)');
+    });
+
+    it('should show hover between to & hovered', () => {
+      const date = new Date();
+
+      const hoveredDate = new Date(date.getFullYear(), date.getMonth(), 5);
+      const middle = new Date(date.getFullYear(), date.getMonth(), 3);
+      const to = new Date(date.getFullYear(), date.getMonth(), 1);
+
+      component.day = middle;
+      component.month = date;
+
+      spyOnProperty(selector, 'to').and.returnValue(to);
+      spyOnProperty(selector, 'hovered').and.returnValue(hoveredDate);
+
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+
+      expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(224, 231, 255)');
+    });
+
+    it('should show hover between hovered & selected from', () => {
+      const date = new Date();
+
+      const hoveredDate = new Date(date.getFullYear(), date.getMonth(), 1);
+      const middle = new Date(date.getFullYear(), date.getMonth(), 2);
+      const from = new Date(date.getFullYear(), date.getMonth(), 5);
+      const to = new Date(date.getFullYear(), date.getMonth(), 9);
+
+      component.day = middle;
+      component.month = date;
+
+      spyOnProperty(selector, 'hovered').and.returnValue(hoveredDate);
+      spyOnProperty(selector, 'from').and.returnValue(from);
+      spyOnProperty(selector, 'to').and.returnValue(to);
+
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+
+      expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(224, 231, 255)');
+    });
+
+    it('should show hover between selected to & hovered', () => {
+      const date = new Date();
+
+      const from = new Date(date.getFullYear(), date.getMonth(), 1);
+      const to = new Date(date.getFullYear(), date.getMonth(), 5);
+      const middle = new Date(date.getFullYear(), date.getMonth(), 7);
+      const hoveredDate = new Date(date.getFullYear(), date.getMonth(), 9);
+
+      component.day = middle;
+      component.month = date;
+
+      spyOnProperty(selector, 'from').and.returnValue(from);
+      spyOnProperty(selector, 'to').and.returnValue(to);
+      spyOnProperty(selector, 'hovered').and.returnValue(hoveredDate);
+
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+
+      expect(window.getComputedStyle(compiled).backgroundColor).toEqual('rgb(224, 231, 255)');
+    });
   });
 });

--- a/projects/cal/src/lib/components/kc-cal-day/kc-cal-day.component.ts
+++ b/projects/cal/src/lib/components/kc-cal-day/kc-cal-day.component.ts
@@ -40,6 +40,8 @@ export class KcCalDayComponent<T extends KcCalSelector = KcCalSelector> implemen
 
   private _destroy: Subject<void>;
 
+  private _isHovered = false;
+
   constructor(@Inject(KC_CAL_SELECTOR) protected _selector: T, private _cdr: ChangeDetectorRef, private _kcCal: KcCal) {
     this._destroy = new Subject();
 
@@ -67,29 +69,36 @@ export class KcCalDayComponent<T extends KcCalSelector = KcCalSelector> implemen
     return this.day.getMonth() !== this.month.getMonth();
   }
 
+  @HostBinding('class.kc-cal-day--selected-other')
+  get selectedOther(): boolean {
+    return this.selected && this.other;
+  }
+
   @HostBinding('class.kc-cal-day--start')
   get start(): boolean {
-    if (!this._selector.from || !this._selector.to) return false;
+    const { from, to, hovered } = this._selector;
 
-    return this._isDateEqual(this.day, this._selector.from);
+    const leftMost = this._findLeftMostDay([from, to, hovered]);
+
+    if (!leftMost) return false;
+
+    return this._isDateEqual(this.day, leftMost);
   }
 
   @HostBinding('class.kc-cal-day--end')
   get end(): boolean {
-    if (!this._selector.from || !this._selector.to) return false;
+    const { from, to, hovered } = this._selector;
 
-    return this._isDateEqual(this.day, this._selector.to);
+    const rightMost = this._findRightMostDay([from, to, hovered]);
+
+    if (!rightMost) return false;
+
+    return this._isDateEqual(this.day, rightMost);
   }
 
   @HostBinding('class.kc-cal-day--rounded')
   get rounded(): boolean {
-    if (this._selector.from && !this._selector.to) return this._isDateEqual(this.day, this._selector.from);
-
-    if (this._selector.to && !this._selector.from) return this._isDateEqual(this.day, this._selector.to);
-
-    if (!this._selector.to || !this._selector.from) return false;
-
-    return this._isDateEqual(this._selector.from, this._selector.to);
+    return this.end && this.start;
   }
 
   @HostBinding('class.kc-cal-day--current')
@@ -97,11 +106,47 @@ export class KcCalDayComponent<T extends KcCalSelector = KcCalSelector> implemen
     return this._isDateEqual(this.day, this._removeTime(new Date()));
   }
 
+  @HostBinding('class.kc-cal-day--hovered')
+  get hovered(): boolean {
+    if (this.selected || this.disabled || !this._selector.hovered) return false;
+
+    const { from, to, hovered } = this._selector;
+
+    // when ranges are not set, hover based on internal state
+    if (!from && !to) return this._isHovered;
+
+    // when 'to' is not set, hover when is between from & hovered dates
+    if (!!from && !to)
+      return this._isDateBetween(this.day, from, hovered) || this._isDateBetween(this.day, hovered, from);
+
+    // when 'from' is not set, hover when is between to & hovered dates
+    if (!from && !!to) return this._isDateBetween(this.day, to, hovered) || this._isDateBetween(this.day, hovered, to);
+
+    // hover when is between either from/to & hovered dates
+    return (
+      (!!from && this._isDateBetween(this.day, from, hovered)) || (!!to && this._isDateBetween(this.day, hovered, to))
+    );
+  }
+
+  @HostBinding('class.kc-cal-day--hovered-other')
+  get hoveredOther(): boolean {
+    return this.hovered && this.other;
+  }
+
   @HostListener('click')
   select(): void {
     if (this.disabled || this.other) return;
 
     this._selector.select(this.day);
+  }
+
+  @HostListener('mouseenter') onMouseEnter() {
+    this._isHovered = true;
+    this._selector.changeHovered(this.day);
+  }
+
+  @HostListener('mouseleave') onMouseLeave() {
+    this._isHovered = false;
   }
 
   ngOnDestroy(): void {
@@ -114,5 +159,29 @@ export class KcCalDayComponent<T extends KcCalSelector = KcCalSelector> implemen
 
   private _removeTime(date: Date): Date {
     return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
+  }
+
+  private _isDateBetween(checkDate: Date, startDate: Date, endDate: Date): boolean {
+    return checkDate >= startDate && checkDate <= endDate;
+  }
+
+  private _findLeftMostDay(dates: (Date | null)[]): Date | null {
+    const validDates = dates.filter((date): date is Date => !!date);
+
+    if (validDates.length === 0) {
+      return null;
+    }
+
+    return validDates.reduce((leftmostDate, date) => (date < leftmostDate ? date : leftmostDate), validDates[0]);
+  }
+
+  private _findRightMostDay(dates: (Date | null)[]): Date | null {
+    const validDates = dates.filter((date): date is Date => !!date);
+
+    if (validDates.length === 0) {
+      return null;
+    }
+
+    return validDates.reduce((rightMostDate, date) => (date > rightMostDate ? date : rightMostDate), validDates[0]);
   }
 }

--- a/projects/cal/src/lib/services/kc-cal-selector/kc-cal-selector.service.ts
+++ b/projects/cal/src/lib/services/kc-cal-selector/kc-cal-selector.service.ts
@@ -11,6 +11,7 @@ export class KcCalSelector implements KcCalBaseSelector<KcCalBaseRange> {
   protected _to: Date | null;
   protected _range: Subject<KcCalBaseRange>;
   protected _rangeSelector: BehaviorSubject<Selector>;
+  protected _hovered: Date | null;
 
   constructor(protected _kcCal: KcCal) {
     this._selector = Selector.From;
@@ -18,6 +19,7 @@ export class KcCalSelector implements KcCalBaseSelector<KcCalBaseRange> {
     this._to = null;
     this._range = new Subject();
     this._rangeSelector = new BehaviorSubject<Selector>(this._selector);
+    this._hovered = null;
   }
 
   get from(): Date | null {
@@ -38,6 +40,10 @@ export class KcCalSelector implements KcCalBaseSelector<KcCalBaseRange> {
 
   get stateChanged(): Observable<Selector> {
     return this._rangeSelector.asObservable();
+  }
+
+  get hovered(): Date | null {
+    return this._hovered;
   }
 
   select(
@@ -102,6 +108,10 @@ export class KcCalSelector implements KcCalBaseSelector<KcCalBaseRange> {
     this._rangeSelector.next(this._selector);
 
     if (options?.goMonth && this.to) this._kcCal.goMonth(this.to, 'to');
+  }
+
+  changeHovered(date: Date) {
+    this._hovered = date;
   }
 
   protected _selectFrom(from: Date | null, options?: { goMonth?: boolean }): void {

--- a/projects/cal/src/lib/types/kc-cal-base-selector.ts
+++ b/projects/cal/src/lib/types/kc-cal-base-selector.ts
@@ -16,4 +16,5 @@ export interface KcCalBaseSelector<T> {
   changed: Observable<T>;
   from: Date | null;
   to: Date | null;
+  hovered: Date | null;
 }


### PR DESCRIPTION
- added hovered state/style for calendar day
- fixed "other" days (offsets) - the 'selected' class shouldn't not be applied

demos:
- both directions
![Screenshot 2023-12-27 at 19 00 11](https://github.com/k5cjs/k5cjs/assets/39920127/ad2a1a09-56e9-4041-9248-b08d303f3360)
![Screenshot 2023-12-27 at 19 00 30](https://github.com/k5cjs/k5cjs/assets/39920127/eff451d2-57b8-408d-9d90-f9d755fbe9dd)
![Screenshot 2023-12-27 at 19 00 45](https://github.com/k5cjs/k5cjs/assets/39920127/03c85810-608a-485d-ad8f-f8cd076255ed)

- "offset" days can be clicked to select next/prev month days
![Screenshot 2023-12-27 at 19 00 58](https://github.com/k5cjs/k5cjs/assets/39920127/98383a4d-5557-4316-9b90-4ab95261037f)
