### PR TITLE
fix: prevent dropdown from shifting and resizing on scroll

### DIFF
--- a/projects/dropdown/package.json
+++ b/projects/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k5cjs/dropdown",
-  "version": "16.0.7",
+  "version": "16.0.8",
   "peerDependencies": {
     "@angular/core": "^16.0.0",
     "@angular/cdk": "^16.0.0"

--- a/projects/dropdown/src/lib/components/internal-dropdown/internal-dropdown.component.ts
+++ b/projects/dropdown/src/lib/components/internal-dropdown/internal-dropdown.component.ts
@@ -56,6 +56,9 @@ export class KcInternalDropdownComponent implements OnDestroy {
         .position()
         .flexibleConnectedTo(this.icon)
         .withPositions(POSITIONS)
+        .withFlexibleDimensions(false)
+        .withGrowAfterOpen(true)
+        .withLockedPosition(true)
         .withPush(false),
       ...this.cdkOverlayConfig,
     });


### PR DESCRIPTION
Fix a dropdown issue where the dropdown could shift position and change size while scrolling. Updated the overlay positioning to keep the dropdown stable during scroll and bumped the package version.